### PR TITLE
Adapt to new spatstat.random package.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,8 +14,8 @@ Description: Simple computation of spatial statistic functions of distance to ch
 URL: https://github.com/EricMarcon/dbmss
 BugReports: https://github.com/EricMarcon/dbmss/issues
 License: GNU General Public License
-Depends: R (>= 3.5.0), spatstat.core, spatstat.geom, Rcpp (>= 0.12.14), ggplot2
-Imports: cubature, RcppParallel, reshape2, spatstat.utils, stats, tibble
+Depends: R (>= 3.5.0), spatstat.core, Rcpp (>= 0.12.14), ggplot2
+Imports: cubature, RcppParallel, reshape2, spatstat.utils, stats, tibble, spatstat.geom, spatstat.random
 Suggests: testthat, knitr, pkgdown, rmarkdown
 LinkingTo: Rcpp, RcppParallel
 VignetteBuilder: knitr

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,6 +2,7 @@ useDynLib("dbmss", .registration = TRUE)
 
 import("spatstat.core")
 import("spatstat.geom")
+importFrom("spatstat.random", "rlabel", "rshift", "runifpoint")
 import("Rcpp")
 importFrom("ggplot2", "autoplot")
 importFrom("RcppParallel", "RcppParallelLibs")


### PR DESCRIPTION
Random generators are being moved from `spatstat.core` to a new package `spatstat.random`. This should hopefully fix the problem for your package.

Seems like my editor has rewritten the line breaks or something like that so it appears all lines have been change when in reality it is only a few. Sorry about that. If it is a big issue maybe you can just make the small changes yourself.

Kind regards,
Ege